### PR TITLE
Make installation of enum34 dependent on Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=find_packages(exclude=['examples']),
     install_requires=[
         'absl-py',
-        'enum34',
+        'enum34 ; python_version < "3.4"',
         'funcsigs ; python_version < "3.3"',
         'numpy',
         'six',


### PR DESCRIPTION
This package should not be installed on newer versions of Python, see https://pypi.org/project/enum34/